### PR TITLE
GUARD-616 SystemStatus Error Woo 4.1.1

### DIFF
--- a/WooCommerce.NET.csproj
+++ b/WooCommerce.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <PackageId>WooCommerceNET.SV</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.1.0.4</Version>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>A .NET Wrapper for WooCommerce REST API. This is a fork of WooCommerce.NET downgraded to .NET Framework 4.6.1 and a number of issues fixed</Description>
@@ -19,10 +19,10 @@ Origin Changes Doc: https://github.com/XiaoFaye/WooCommerce.NET/blob/master/Chan
 * v0.7.6 update
   1. Supporting WooCommerce Restful API V3.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <AssemblyVersion>1.1.0.4</AssemblyVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.key.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>1.1.1.0</FileVersion>
+    <FileVersion>1.1.0.4</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/WooCommerce.NET.csproj
+++ b/WooCommerce.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <PackageId>WooCommerceNET.SV</PackageId>
-    <Version>1.1.0.4</Version>
+    <Version>1.1.1</Version>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>A .NET Wrapper for WooCommerce REST API. This is a fork of WooCommerce.NET downgraded to .NET Framework 4.6.1 and a number of issues fixed</Description>
@@ -19,10 +19,10 @@ Origin Changes Doc: https://github.com/XiaoFaye/WooCommerce.NET/blob/master/Chan
 * v0.7.6 update
   1. Supporting WooCommerce Restful API V3.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.0.4</AssemblyVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.key.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>1.1.0.4</FileVersion>
+    <FileVersion>1.1.1.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/WooCommerce.NET.csproj
+++ b/WooCommerce.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <PackageId>WooCommerceNET.SV</PackageId>
-    <Version>1.1.0.4</Version>
+    <Version>1.1.5</Version>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>A .NET Wrapper for WooCommerce REST API. This is a fork of WooCommerce.NET downgraded to .NET Framework 4.6.1 and a number of issues fixed</Description>
@@ -19,10 +19,10 @@ Origin Changes Doc: https://github.com/XiaoFaye/WooCommerce.NET/blob/master/Chan
 * v0.7.6 update
   1. Supporting WooCommerce Restful API V3.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.0.4</AssemblyVersion>
+    <AssemblyVersion>1.1.5.0</AssemblyVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.key.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>1.1.0.4</FileVersion>
+    <FileVersion>1.1.5.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/WooCommerce/v2/SystemStatus.cs
+++ b/WooCommerce/v2/SystemStatus.cs
@@ -404,6 +404,13 @@ namespace WooCommerceNET.WooCommerce.v2
         public bool? has_outdated_templates { get; set; }
 
         /// <summary>
+        /// Template overrides. 
+        /// read-only
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public List<string> overrides { get; set; }
+
+        /// <summary>
         /// Parent theme name. 
         /// read-only
         /// </summary>

--- a/WooCommerce/v2/SystemStatus.cs
+++ b/WooCommerce/v2/SystemStatus.cs
@@ -404,13 +404,6 @@ namespace WooCommerceNET.WooCommerce.v2
         public bool? has_outdated_templates { get; set; }
 
         /// <summary>
-        /// Template overrides. 
-        /// read-only
-        /// </summary>
-        [DataMember(EmitDefaultValue = false)]
-        public List<string> overrides { get; set; }
-
-        /// <summary>
         /// Parent theme name. 
         /// read-only
         /// </summary>


### PR DESCRIPTION
Removed systemStatus > theme >overrides, since in 4.1.1 each override might contain undocumented fields (in the api docs). We don't need them anyway