### PR TITLE
2020-06-30 GUARD-656 Orders-Sync-Error

### DIFF
--- a/WooCommerce.NET.csproj
+++ b/WooCommerce.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <PackageId>WooCommerceNET.SV</PackageId>
-    <Version>1.1.5</Version>
+    <Version>1.1.6</Version>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>A .NET Wrapper for WooCommerce REST API. This is a fork of WooCommerce.NET downgraded to .NET Framework 4.6.1 and a number of issues fixed</Description>
@@ -19,10 +19,10 @@ Origin Changes Doc: https://github.com/XiaoFaye/WooCommerce.NET/blob/master/Chan
 * v0.7.6 update
   1. Supporting WooCommerce Restful API V3.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.5.0</AssemblyVersion>
+    <AssemblyVersion>1.1.6.0</AssemblyVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.key.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>1.1.5.0</FileVersion>
+    <FileVersion>1.1.6.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/WooCommerce/Legacy/Customer.cs
+++ b/WooCommerce/Legacy/Customer.cs
@@ -26,7 +26,22 @@ namespace WooCommerceNET.WooCommerce.Legacy
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public DateTime? created_at { get; set; }
+        public string created_at_value { get; set; }
+        public DateTime? created_at
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(this.created_at_value))
+                    return DateTime.MinValue;
+
+                DateTime.TryParse(this.created_at_value, out DateTime date);
+                return date;
+            }
+            set
+            {
+                this.created_at_value = value?.ToString() ?? null;
+            }
+        }
 
         /// <summary>
         /// Customer email address 


### PR DESCRIPTION
Summary
Customer's created date field can have incorrect date and time value. 
For example: 
`"customer": {
   "id": 171,
   "created_at": "-0001-11-30T07:52:58Z",
   "last_update": "2019-04-14T16:19:10Z",
   ...
`