### PR TITLE
2021-01-19 GUARD-1723 WooCommerce: Full Inventory Sync failing

### DIFF
--- a/WooCommerce/v2/SystemStatus.cs
+++ b/WooCommerce/v2/SystemStatus.cs
@@ -125,7 +125,7 @@ namespace WooCommerceNET.WooCommerce.v2
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public int? wp_memory_limit { get; set; }
+        public long? wp_memory_limit { get; set; }
 
         /// <summary>
         /// Is WordPress debug mode active? 


### PR DESCRIPTION
I researched the logs and I can assume that there is a bug in the type of the wp_memory_limit field in the SystemStatusEnvironment class. It seems the value passed to it can exceed the limit (the WordPress keep it in bytes so 4GB exceed the limit for int32). 

I modified SystemStatusEnvironment.wp_memory_limit field type from "int" to "long" to support of values equal or more than 2GB (2147483648 bytes)

The problem exist for all WooCommerce accounts which has setting wp_memory_limit >= 2GB

![23d877fe-1d6a-4273-8ea2-137876432ab4](https://user-images.githubusercontent.com/7067568/105000449-67739680-5a3f-11eb-9847-f4244917d369.png)
